### PR TITLE
More header fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jekyll-uswds (0.4.0)
+    uswds-jekyll (1.0.0)
       jekyll (~> 3.4)
 
 GEM
@@ -49,8 +49,8 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.12)
-  jekyll-uswds!
   rake (~> 10.0)
+  uswds-jekyll!
 
 BUNDLED WITH
    1.13.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jekyll-uswds (0.1.1)
+    jekyll-uswds (0.4.0)
       jekyll (~> 3.4)
 
 GEM
@@ -12,7 +12,7 @@ GEM
     colorator (1.1.0)
     ffi (1.9.18)
     forwardable-extended (2.6.0)
-    jekyll (3.4.1)
+    jekyll (3.4.2)
       addressable (~> 2.4)
       colorator (~> 1.0)
       jekyll-sass-converter (~> 1.0)

--- a/_includes/components/header.html
+++ b/_includes/components/header.html
@@ -7,8 +7,8 @@
     <button class="usa-menu-btn">Menu</button>
     <div class="usa-logo" id="logo">
       <em class="usa-logo-text">
-        <a href="{{ header.href | default: site.baseurl }}"
-          title="Home" aria-label="Home">{{ header.title | default: site.title }}
+        <a href="{{ header.href | default: site.baseurl }}" title="Home">
+          {{ header.title | default: site.title }}
         </a>
       </em>
     </div>

--- a/_includes/components/header.html
+++ b/_includes/components/header.html
@@ -7,7 +7,8 @@
     <button class="usa-menu-btn">Menu</button>
     <div class="usa-logo" id="logo">
       <em class="usa-logo-text">
-        <a href="#" accesskey="1" title="Home" aria-label="Home">{{ header.title | default: site.title }}</a>
+        <a href="{{ header.href | default: site.baseurl }}"
+          title="Home" aria-label="Home">{{ header.title | default: site.title }}</a>
       </em>
     </div>
   </div>

--- a/_includes/components/header.html
+++ b/_includes/components/header.html
@@ -40,7 +40,7 @@
             {% endfor %}
           </ul>
           {% else %}
-          <a class="usa-nav-link" href="{{ _section.href | relative_url }}">
+          <a class="usa-nav-link{% if _section.href == page.permalink %} usa-current{% endif %}" href="{{ _section.href | relative_url }}">
             <span>{{ _section.text }}</span>
           </a>
           {% endif %}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "author": "18F",
   "license": "CC0-1.0",
   "scripts": {
+    "postinstall": "bundle",
+    "start": "bundle exec jekyll serve",
     "update-uswds": "npm run update-assets && npm run update-sass",
     "update-assets": "rsync -avr --delete node_modules/uswds/dist/ assets/uswds/",
     "update-sass": "rsync -avr --delete node_modules/uswds/src/stylesheets/ _sass/uswds/"

--- a/uswds-jekyll.gemspec
+++ b/uswds-jekyll.gemspec
@@ -1,8 +1,8 @@
 # coding: utf-8
 
 Gem::Specification.new do |spec|
-  spec.name          = "jekyll-uswds"
-  spec.version       = "0.4.0"
+  spec.name          = "uswds-jekyll"
+  spec.version       = "1.0.0"
   spec.authors       = ["Shawn Allen"]
   spec.email         = ["shawn.allen@gsa.gov"]
 


### PR DESCRIPTION
1. Add `usa-current` class to active primary nav links
1. Allow for a header `href` property to control the site title link
1. Remove `accesskey="1"` per 18F/web-design-standards#1772
1. Add `npm start` script and `postinstall` hook to run `bundle`

@maya do you mind reviewing this one?