### PR TITLE
Rename gem from `jekyll-uswds` to `uswds-jekyll`

### DIFF
--- a/jekyll-uswds.gemspec
+++ b/jekyll-uswds.gemspec
@@ -1,0 +1,22 @@
+# coding: utf-8
+
+Gem::Specification.new do |spec|
+  spec.post_install_message = "Hey, this gem is deprecated! Please update your 
+  Gemfile and replace 'jekyll-uswds' with 'uswds-jekyll'"
+
+  spec.name          = "jekyll-uswds"
+  spec.version       = "0.4.1"
+  spec.authors       = ["Shawn Allen"]
+  spec.email         = ["shawn.allen@gsa.gov"]
+
+  spec.summary       = %q{A Jekyll theme for the U.S. Web Design Standards}
+  spec.homepage      = "https://standards.usa.gov/"
+  spec.license       = "CC0-1.0"
+
+  spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(assets|_layouts|_includes|_sass|LICENSE|README)}i) }
+
+  spec.add_runtime_dependency "jekyll", "~> 3.4"
+
+  spec.add_development_dependency "bundler", "~> 1.12"
+  spec.add_development_dependency "rake", "~> 10.0"
+end

--- a/uswds-jekyll.gemspec
+++ b/uswds-jekyll.gemspec
@@ -15,5 +15,4 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "jekyll", "~> 3.4"
 
   spec.add_development_dependency "bundler", "~> 1.12"
-  spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
Fixes #1. I've included a gemspec for the `jekyll-uswds` gem for backwards compatibility, but only projects that explicitly update their dependencies to `uswds-jekyll` will get changes from here on out.

This will bump the version to 1.0.0.

cc for visibility: @maya @hbillings @hursey013 @line47 @gemfarmer (anyone else?)