### PR TITLE
Add forward slash to logo link

### DIFF
--- a/_includes/components/header.html
+++ b/_includes/components/header.html
@@ -7,7 +7,7 @@
     <button class="usa-menu-btn">Menu</button>
     <div class="usa-logo" id="logo">
       <em class="usa-logo-text">
-        <a href="{{ header.href | default: site.baseurl }}/" title="Home">
+        <a href="{% if header.href %}{{ header.href }}{% else %}{{ site.baseurl }}/{% endif %}" title="Home">
           {{ header.title | default: site.title }}
         </a>
       </em>

--- a/_includes/components/header.html
+++ b/_includes/components/header.html
@@ -7,7 +7,7 @@
     <button class="usa-menu-btn">Menu</button>
     <div class="usa-logo" id="logo">
       <em class="usa-logo-text">
-        <a href="{{ header.href | default: site.baseurl }}" title="Home">
+        <a href="{{ header.href | default: site.baseurl }}/" title="Home">
           {{ header.title | default: site.title }}
         </a>
       </em>


### PR DESCRIPTION
This will allow the site link to link to the home page. It needs the forward slash bc `site.baseurl` is blank by default.