### PR TITLE
Remove use of usa-width-one-whole from landing page

### DIFF
--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -23,9 +23,7 @@ layout: base
 
 <section class="usa-section">
   <div class="usa-grid">
-    <div class="usa-width-one-whole">
     {{ content }}
-    </div>
   </div>
 </section>
 


### PR DESCRIPTION
The landing page uses `usa-width-one-whole`, but it's not needed and can just put content inside `usa-grid`. This would also allow folks to add their own columns into this.