### PR TITLE
Refactoring header component to add both basic and extended options

### DIFF
--- a/_data/header.yml
+++ b/_data/header.yml
@@ -3,7 +3,12 @@
 # Uncomment this statement (by removing the leading '# ') to set the
 # header title differently from the site's title (as defined in
 # _config.yml).
+
 # title: Header title
+
+# this defines the type of header
+# header types can be 'basic' or 'extended'
+type: basic
 
 primary:
   # this is a key into _data/navigation.yml
@@ -13,10 +18,8 @@ secondary:
   # this is a key into _data/navigation.yml
   links: secondary
 
-  # to enable search, change this to an object with 'action' and
-  # 'param' keys, e.g.
-  #
-  # search:
-  #   action: /search/
-  #   param: q
-  search: false
+# to enable search, change this to an object with 'action' and
+# 'param' keys, e.g.
+#  search:
+#    action: /search/
+#    param: q

--- a/_includes/components/header--basic.html
+++ b/_includes/components/header--basic.html
@@ -1,0 +1,75 @@
+{% if header %}
+{% include banner.html %}
+<header class="usa-header usa-header-{{ header.type | default: 'extended' }}" role="banner">
+  {% if header %}
+  <div class="usa-nav-container">
+    <div class="usa-navbar">
+      <button class="usa-menu-btn">Menu</button>
+      <div class="usa-logo" id="logo">
+        <em class="usa-logo-text">
+          <a href="{% if header.href %}{{ header.href }}{% else %}{{ site.baseurl }}/{% endif %}" title="Home">
+            {{ header.title | default: site.title }}
+          </a>
+        </em>
+      </div>
+    </div>
+
+    <nav role="navigation" class="usa-nav">
+      <div class="usa-nav-inner">
+        <button class="usa-nav-close">
+          <img src="{{ site.baseurl }}/assets/uswds/img/close.svg" alt="close">
+        </button>
+
+        {% assign _primary = header.primary.links %}
+        {% assign primary_links = site.data.navigation[_primary] | default: _primary %}
+        {% if primary_links %}
+        <ul class="usa-nav-primary usa-accordion">
+          {% for _section in primary_links %}
+          <li>
+            {% if _section.links %}
+              {% assign section_links = site.data.navigation[_section.links] | default: _section.links %}
+              {% assign _section_id = _section.id %}
+              {% unless _section_id %}{% assign _section_id = 'nav-' | append: forloop.index %}{% endunless %}
+            <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="{{ _section_id }}">
+              <span>{{ _section.text }}</span>
+            </button>
+            <ul id="{{ _section_id }}" class="usa-nav-submenu">
+              {% for _link in section_links %}
+              <li>
+                <a href="{% if _link.external == true %}{{ _link.href }}{% else %}{{ _link.href | relative_url }}{% endif %}">{{ _link.text }}</a>
+              </li>
+              {% endfor %}
+            </ul>
+            {% else %}
+            <a class="usa-nav-link{% if _section.href == page.permalink %} usa-current{% endif %}" href="{% if _section.external == true %}{{ _section.href }}{% else %}{{ _section.href | relative_url }}{% endif %}">
+              <span>{{ _section.text }}</span>
+            </a>
+            {% endif %}
+          </li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+
+        {% assign _secondary = header.secondary %}
+
+
+          {% if _secondary.search %}
+          <div class="usa-search usa-search-small" role="search">
+            <form action="{{ _secondary.search.action | relative_url }}">
+                <label class="usa-sr-only" for="search-field-small">Search small</label>
+                <input id="search-field-small" type="search" name="{{ _secondary.search.query | default: 'search' }}">
+                <button type="submit">
+                  <span class="usa-sr-only">Search</span>
+                </button>
+            </form>
+          </div>
+          {% endif %}
+        </div>
+      </div>
+    </nav>
+  </div>
+  {% endif %}
+
+</header>
+<div class="usa-overlay"></div>
+{% endif %}

--- a/_includes/components/header--basic.html
+++ b/_includes/components/header--basic.html
@@ -1,5 +1,5 @@
 {% if header %}
-<header class="usa-header usa-header-{{ header.type | default: 'extended' }}" role="banner">
+<header class="usa-header usa-header-basic" role="banner">
   {% include banner.html %}
   <div class="usa-nav-container">
     <div class="usa-navbar">

--- a/_includes/components/header--basic.html
+++ b/_includes/components/header--basic.html
@@ -1,7 +1,6 @@
 {% if header %}
 {% include banner.html %}
 <header class="usa-header usa-header-{{ header.type | default: 'extended' }}" role="banner">
-  {% if header %}
   <div class="usa-nav-container">
     <div class="usa-navbar">
       <button class="usa-menu-btn">Menu</button>
@@ -68,8 +67,6 @@
       </div>
     </nav>
   </div>
-  {% endif %}
-
 </header>
 <div class="usa-overlay"></div>
 {% endif %}

--- a/_includes/components/header--basic.html
+++ b/_includes/components/header--basic.html
@@ -1,6 +1,6 @@
 {% if header %}
-{% include banner.html %}
 <header class="usa-header usa-header-{{ header.type | default: 'extended' }}" role="banner">
+  {% include banner.html %}
   <div class="usa-nav-container">
     <div class="usa-navbar">
       <button class="usa-menu-btn">Menu</button>

--- a/_includes/components/header--extended.html
+++ b/_includes/components/header--extended.html
@@ -1,7 +1,6 @@
 {% if header %}
+{% include banner.html %}
 <header class="usa-header usa-header-{{ header.type | default: 'extended' }}" role="banner">
-  {% include banner.html %}
-
   {% if header %}
   <div class="usa-navbar">
     <button class="usa-menu-btn">Menu</button>

--- a/_includes/components/header--extended.html
+++ b/_includes/components/header--extended.html
@@ -1,5 +1,5 @@
 {% if header %}
-<header class="usa-header usa-header-{{ header.type | default: 'extended' }}" role="banner">
+<header class="usa-header usa-header-extended" role="banner">
   {% include banner.html %}
   <div class="usa-navbar">
     <button class="usa-menu-btn">Menu</button>

--- a/_includes/components/header--extended.html
+++ b/_includes/components/header--extended.html
@@ -1,7 +1,6 @@
 {% if header %}
-{% include banner.html %}
 <header class="usa-header usa-header-{{ header.type | default: 'extended' }}" role="banner">
-  {% if header %}
+  {% include banner.html %}
   <div class="usa-navbar">
     <button class="usa-menu-btn">Menu</button>
     <div class="usa-logo" id="logo">
@@ -81,8 +80,6 @@
 
     </div>
   </nav>
-  {% endif %}
-
 </header>
 <div class="usa-overlay"></div>
 {% endif %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,2 +1,7 @@
 {% assign header = site.data.header %}
-{% include components/header.html %}
+
+{% if header.type == 'basic' %}
+  {% include components/header--basic.html %}
+{% else %}
+  {% include components/header--extended.html %}
+{% endif %}


### PR DESCRIPTION
This addresses issue https://github.com/18F/uswds-jekyll/issues/21

You can set different header options by changing the `header.yml`config file.

```
# this defines the type of header
# header types can be 'basic' or 'extended'
type: basic
```