### PR TITLE
Update stylesheet include logic

### DIFF
--- a/_includes/styles.html
+++ b/_includes/styles.html
@@ -9,9 +9,10 @@
   | push: _site_styles
   | push: layout.styles
   | push: page.styles
-  | uniq %}
-{% for _list in _styles %}{% for _style in _list %}
+  | uniq
+  | compact %}
+{% for _style in _styles %}
 <link rel="stylesheet"
   href="{{ _style.href | default: _style | relative_url }}"
   media="{{ _style.media | default: 'screen' }}">
-{% endfor %}{% endfor %}
+{% endfor %}


### PR DESCRIPTION
This is a fix for: https://github.com/18F/uswds-jekyll/issues/47

From my testing, using the `uniq` filter flattens everything into a single array so having the loop within a loop: `{% for _list in _styles %}{% for _style in _list %}` was causing issues. Also, I think pushing some of the empty arrays in to the larger `_styles` array was causing some `nil` values which were then showing up as empty stylesheet tags in the final output.

I tested quite a few variations of including stylesheets within the _`config.yml`, layout, and page and it seemed to worked consistently, but would appreciate a second pair of eyes if anyone is more familiar with using liquid arrays.