### PR TITLE
Associate label with search field

### DIFF
--- a/_includes/components/header--extended.html
+++ b/_includes/components/header--extended.html
@@ -54,7 +54,7 @@
         {% if _secondary.search %}
           <form action="{{ _secondary.search.action | relative_url }}" class="usa-search usa-search-small js-search-form">
           <div role="search">
-            <label class="usa-sr-only" for="search-field">Search small</label>
+            <label class="usa-sr-only" for="search-input">Search small</label>
             <input id="search-input" type="search" name="{{ _secondary.search.query | default: 'search' }}">
             <button type="submit">
               <span class="usa-sr-only">Search</span>


### PR DESCRIPTION
This came up on an a11y scan: `Form elements do not have associated labels.`

Looks like we have a label for the search field but it's not currently associated with the input field, so this remedies that.