### PR TITLE
Adding the option of using Google analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is a [Jekyll theme](https://jekyllrb.com/docs/themes/) for the
     - [Navigation](#navigation)
     - [Page subnavigation](#page-subnavigation)
     - [Search](#search)
-    - [Google Analytics](#google-analytics)
+    - [Analytics](#analytics)
 1. [Assets](#assets)
     - [Stylesheets](#stylesheets)
     - [Scripts](#scripts)
@@ -241,13 +241,24 @@ Search uses the [Search results](#search-results) page layout.
 
 **Pro tip:** use [Jekyll front matter defaults](https://jekyllrb.com/docs/configuration/#front-matter-defaults) to hide directories from showing in search results.
 
-### Google Analytics
+### Analytics
 
-You can add Google analytics to your site by uncommenting the `google_analytics_ua` line and replacing `UA-????????-??` with your Google analytics UA code.
+#### Google Analytics
+
+You can add Google Analytics to your site by uncommenting the `google_analytics_ua` line and replacing `UA-????????-??` with your Google analytics UA code.
 
 ```
 # Configuration for Google Analytics, add your UA code here:
 # google_analytics_ua: UA-????????-??
+```
+
+#### Digital Analytics Program (DAP)
+
+You can add DAP to your site by uncommenting the `dap_agency` line and, if need be, replacing `GSA` with the appropriate agency key. For more information visit <https://www.digitalgov.gov/services/dap/>
+
+```
+# Configuration for DAP, add your agency ID here:
+# dap_agency: GSA
 ```
 
 ## Assets

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This is a [Jekyll theme](https://jekyllrb.com/docs/themes/) for the
     - [Navigation](#navigation)
     - [Page subnavigation](#page-subnavigation)
     - [Search](#search)
+    - [Google Analytics](#google-analytics)
 1. [Assets](#assets)
     - [Stylesheets](#stylesheets)
     - [Scripts](#scripts)
@@ -239,6 +240,15 @@ redcarpet:
 Search uses the [Search results](#search-results) page layout.
 
 **Pro tip:** use [Jekyll front matter defaults](https://jekyllrb.com/docs/configuration/#front-matter-defaults) to hide directories from showing in search results.
+
+### Google Analytics
+
+You can add Google analytics to your site by uncommenting the `google_analytics_ua` line and replacing `UA-????????-??` with your Google analytics UA code.
+
+```
+# Configuration for Google Analytics, add your UA code here:
+# google_analytics_ua: UA-????????-??
+```
 
 ## Assets
 

--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,9 @@ title: This is the site title
 # Configuration for Google Analytics, add your UA code here:
 # google_analytics_ua: UA-????????-??
 
+# Configuration for DAP, add your agency ID here:
+# dap_agency: GSA
+
 # Configuration for jekyll_pages_api_search plugin gem.
 jekyll_pages_api_search:
   # Uncomment this to speed up site generation while developing.

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,8 @@
 title: This is the site title
 
+# Configuration for Google Analytics, add your UA code here:
+# google_analytics_ua: UA-????????-??
+
 # Configuration for jekyll_pages_api_search plugin gem.
 jekyll_pages_api_search:
   # Uncomment this to speed up site generation while developing.
@@ -17,7 +20,9 @@ jekyll_pages_api_search:
       boost: 5
     body:
   results_page_title: Search results # Used for the title tag and the header on the results page
-# Skip indexing of the assets/uswds directory
+
+# Page defaults
+# This default setting is used in conjunction with the jekyll_pages_api_search to hide results from the USWDS from showing up in the search results
 defaults:
   - scope:
       path: "assets/uswds"

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -26,13 +26,9 @@ primary:
     href: https://18f.gsa.gov
     external: true
 
-secondary: []
-
-footer:
+secondary:
   - text: Documentation
     href: /docs/
-  - text: Demo link
-    href: /demo/
   - text: External link
     href: https://18f.gsa.gov
     external: true
@@ -40,12 +36,25 @@ footer:
 docs:
   - text: Documentation
     href: /docs/
-  - text: Installation
-    href: /docs/install/
-  - text: Upgrading
-    href: /docs/upgrade/
-  - text: Help
-    href: /docs/help/
+  - text: Navigation section
+    links:
+      - text: Demo link A
+        href: /two/a/
+      - text: Demo link B
+        href: /two/b/
+      - text: Demo link C
+        href: /two/c/
+  - text: Referenced section
+    links: footer
+  - text: External link
+    href: https://18f.gsa.gov
+    external: true
+
+footer:
+  - text: Documentation
+    href: /docs/
+  - text: Demo link
+    href: /demo/
   - text: External link
     href: https://18f.gsa.gov
     external: true

--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,4 +1,4 @@
-
+{% if site.google_analytics_ua %}
 <!-- Google Analytics -->
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -12,6 +12,9 @@
   ga('set', 'forceSSL', true);
   ga('send', 'pageview');
 </script>
+{% endif %}
 
+{% if site.dap_agency %}
 <!-- Digital Analytics Program roll-up, see https://analytics.usa.gov for data -->
-<script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA"></script>
+<script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency={{ site.dap_agency }}"></script>
+{% endif %}

--- a/_includes/google-analytics.html
+++ b/_includes/google-analytics.html
@@ -1,0 +1,17 @@
+
+<!-- Google Analytics -->
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+  ga('create', '{{ site.google_analytics_ua }}', 'auto');
+
+  // anonymize user IPs (chops off the last IP triplet)
+  ga('set', 'anonymizeIp', true);
+  ga('set', 'forceSSL', true);
+  ga('send', 'pageview');
+</script>
+
+<!-- Digital Analytics Program roll-up, see https://analytics.usa.gov for data -->
+<script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,6 +16,9 @@
     </main>
 
     {% include footer.html %}
+    {% if site.google_analytics_ua %}
+      {% include google-analytics.html %}
+    {% endif %}
     {% include scripts.html %}
   </body>
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,8 +16,8 @@
     </main>
 
     {% include footer.html %}
-    {% if site.google_analytics_ua %}
-      {% include google-analytics.html %}
+    {% if site.google_analytics_ua or site.dap_agency %}
+      {% include analytics.html %}
     {% endif %}
     {% include scripts.html %}
   </body>


### PR DESCRIPTION
Followed the same format the guides-style is using for adding GA. 
This addresses https://github.com/18F/uswds-jekyll/issues/64