### PR TITLE
Updating search-results layout to inherit default

### DIFF
--- a/_layouts/search-results.html
+++ b/_layouts/search-results.html
@@ -1,5 +1,5 @@
 ---
-layout: base
+layout: default
 hide_edit_link: true
 main:
   class: usa-grid usa-section usa-content


### PR DESCRIPTION
Currently it was inheriting `base` layout and that was updated to `default `in PR https://github.com/18F/uswds-jekyll/pull/40 but was missed in this layout.