### PR TITLE
Fix to stop dropdowns and search box from flickering on page load

### DIFF
--- a/_includes/components/header--basic.html
+++ b/_includes/components/header--basic.html
@@ -32,7 +32,7 @@
             <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="{{ _section_id }}">
               <span>{{ _section.text }}</span>
             </button>
-            <ul id="{{ _section_id }}" class="usa-nav-submenu">
+            <ul id="{{ _section_id }}" class="usa-nav-submenu" aria-hidden="true">
               {% for _link in section_links %}
               <li>
                 <a href="{% if _link.external %}{{ _link.href }}{% else %}{{ _link.href | relative_url }}{% endif %}">{{ _link.text }}</a>
@@ -54,7 +54,7 @@
 
           {% if _secondary.search %}
           <div class="usa-search usa-search-small" role="search">
-            <form action="{{ _secondary.search.action | relative_url }}">
+            <form action="{{ _secondary.search.action | relative_url }}" class="usa-sr-only">
                 <label class="usa-sr-only" for="search-field-small">Search small</label>
                 <input id="search-field-small" type="search" name="{{ _secondary.search.query | default: 'search' }}">
                 <button type="submit">

--- a/_includes/components/header--extended.html
+++ b/_includes/components/header--extended.html
@@ -31,7 +31,7 @@
           <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="{{ _section_id }}">
             <span>{{ _section.text }}</span>
           </button>
-          <ul id="{{ _section_id }}" class="usa-nav-submenu">
+          <ul id="{{ _section_id }}" class="usa-nav-submenu" aria-hidden="true">
             {% for _link in section_links %}
             <li>
               <a href="{% if _link.external %}{{ _link.href }}{% else %}{{ _link.href | relative_url }}{% endif %}">{{ _link.text }}</a>
@@ -52,7 +52,7 @@
       {% if _secondary %}
       <div class="usa-nav-secondary">
         {% if _secondary.search %}
-          <form action="{{ _secondary.search.action | relative_url }}" class="usa-search usa-search-small js-search-form">
+          <form action="{{ _secondary.search.action | relative_url }}" class="usa-search usa-search-small js-search-form usa-sr-only">
           <div role="search">
             <label class="usa-sr-only" for="search-input">Search small</label>
             <input id="search-input" type="search" name="{{ _secondary.search.query | default: 'search' }}">


### PR DESCRIPTION
Preview: https://federalist-proxy.app.cloud.gov/preview/18f/uswds-jekyll/no-flicker/

There is still a fade in from `usa-overlay` that will be addressed by the USWDS team. Will merge that in once it is added into an official release - https://github.com/18F/web-design-standards/pull/2275