### PR TITLE
Update new site instructions to include 'jekyll_pages_api_search' step

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ You will need to restart your Jekyll server to see the effects.
     ```ruby
     gem 'uswds-jekyll', :git => 'https://github.com/18F/uswds-jekyll.git'
     ```
+1. Install the `jekyll_pages_api_search` by adding it to your `Gemfile`:
+    ```
+    group :jekyll_plugins do
+      gem 'jekyll_pages_api_search'
+    end
+    ```
 1. Set the `theme` in your site's Jekyll configuration,
    `_config.yml`:
 


### PR DESCRIPTION
Adding the instruction to update the Gemfile in new jekyll sites to include the 'jekyll_pages_api_search' gem. Otherwise, jekyll serve errors out.

Error received before adding the gem: 
<img width="1043" alt="screen shot 2017-12-21 at 9 31 43 am" src="https://user-images.githubusercontent.com/2197515/34259859-d884d1a2-e631-11e7-9231-2c91f0bf0306.png">
