### PR TITLE
Remove layout modifications for new site setup 

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,13 +89,6 @@ You will need to restart your Jekyll server to see the effects.
     ```yml
     theme: uswds-jekyll
     ```
-1. Update the layouts used on the following pages to use [uswds-jekyll layouts](https://github.com/18F/uswds-jekyll/tree/master/_layouts)
-    ```
-    404.html
-    index.md
-    about.md
-    posts/2017-08-07-welcome-to-jekyll.markdown
-    ```
 1. Fetch and update your bundled gems by running:
 
     ```sh


### PR DESCRIPTION
Removing the step to update your layouts when creating a new site. We are now using GitHub default layouts and don't need to modify the layout names to get started with a new site.