### PR TITLE
Show search in basic header

### DIFF
--- a/_includes/components/header--basic.html
+++ b/_includes/components/header--basic.html
@@ -54,7 +54,7 @@
 
           {% if _secondary.search %}
           <div class="usa-search usa-search-small" role="search">
-            <form action="{{ _secondary.search.action | relative_url }}" class="usa-sr-only">
+            <form action="{{ _secondary.search.action | relative_url }}">
                 <label class="usa-sr-only" for="search-field-small">Search small</label>
                 <input id="search-field-small" type="search" name="{{ _secondary.search.query | default: 'search' }}">
                 <button type="submit">


### PR DESCRIPTION
The class `usa-sr-only` was hiding the search box for the basic heading.
Removing that class and the search now shows 👍 

![screen shot 2018-01-03 at 10 58 34 am](https://user-images.githubusercontent.com/1449852/34527846-ed9de40a-f074-11e7-965e-e8c145aaf1fa.png)
