### PR TITLE
Conditionally include search javascript

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -23,6 +23,8 @@
 <script src="{{ _src | replace: _async_marker, '' | relative_url }}"{% if _script.async or _src contains _async_marker %} async{% endif %}></script>
 {% endfor %}{% endfor %}
 
-{% if page.layout == 'search-results' %}
-{% jekyll_pages_api_search_load %}
+{% if site.jekyll_pages_api_search and page.layout == 'search-results' %}
+<script>JEKYLL_PAGES_API_SEARCH_BASEURL = '{{ site.baseurl }}';</script>
+<script async src="{{ site.baseurl }}/assets/js/search-bundle.js">
+</script>
 {% endif %}


### PR DESCRIPTION
This relates to https://github.com/18F/uswds-jekyll/issues/85

It turns out that you can't currently test if a plugin is installed with Jekyll:
https://github.com/jekyll/jekyll/issues/6020
https://github.com/jekyll/jekyll/pull/6046

So rather than using the `{% jekyll_pages_api_search_load %}` tag included with https://github.com/18F/jekyll_pages_api_search, this updates the theme to directly embed the required javascript if `jekyll_pages_api_search` is defined in the _config.yml. The end result is the same as using the `{% jekyll_pages_api_search_load %}` tag - I think the main benefit of using the tag relates to using the plugin with Browserify, which is beyond the scope of the theme anyways.
