### PR TITLE
Adding links back in

### DIFF
--- a/demo/home.md
+++ b/demo/home.md
@@ -46,7 +46,9 @@ graphics:
     description: In addition to your goal, find out your users’ goals. [What do they want to know](https://18f.gsa.gov/) or do that supports your mission? Use these headings to show those.
 ---
 
-<h2>Section heading</h2>
-<p class="usa-font-lead">Everything up to this point should <a href="https://18f.gsa.gov/">help people understand</a> your agency or project: who you are, your goal or mission, and how you approach it. Use this section to encourage them to act. Describe why they should get in touch here, and use an active verb on the button below. “Get in touch,” “Learn more,” and so on.</p>
-<a class="usa-button usa-button-big" href="#">Call to action</a>
+## Section heading
 
+Everything up to this point [should help people](javascript:void(0);) understand your agency or project: who you are, your goal or mission, and how you approach it. Use this section to encourage them to act. Describe why they should get in touch here, and use an active verb on the button below. “Get in touch,” “Learn more,” and so on.
+{: .usa-font-lead }
+
+[Call to action](#){: .usa-button .usa-button-big }

--- a/demo/home.md
+++ b/demo/home.md
@@ -5,7 +5,7 @@ permalink: /
 layout: home
 
 hero:
-  image: /assets/img/hero.png
+  image: /assets/uswds/img/hero.png
   callout:
     alt: "Hero callout:"
     text: Call attention to a current priority
@@ -19,36 +19,34 @@ hero:
 
 tagline: A tagline highlights your approach.
 intro: |
-  The tagline should inspire confidence and interest, focusing on the value that your overall approach offers to your audience. Use a heading typeface and keep your tagline to just a few words, and don’t confuse or mystify.
+  The tagline should inspire confidence and interest, [focusing on the value](javascript:void(0);) that your overall approach offers to your audience. Use a heading typeface and keep your tagline to just a few words, and don’t confuse or mystify.
 
   Use the right side of the grid to explain the tagline a bit more. What are your goals? How do you do your work? Write in the present tense, and stay brief here. People who are interested can find details on internal pages.
 
 graphics:
   - image:
-      src: /assets/img/circle.png
+      src: /assets/uswds/img/circle-124.png
       alt: ''
     title: Graphic headings can vary.
-    description: Graphic headings can be used a few different ways, depending on what your landing page is for. Highlight your values, specific program areas, or results.
+    description: Graphic headings can be used a few [different ways](javascript:void(0);), depending on what your landing page is for. Highlight your values, specific program areas, or results.
   - image:
-      src: /assets/img/circle.png
+      src: /assets/uswds/img/circle-124.png
       alt: ''
     title: Stick to 6 or fewer words.
     description: Keep body text to about 30. They can be shorter, but try to be somewhat balanced across all four. It creates a clean appearance with good spacing.
   - image:
-      src: /assets/img/circle.png
+      src: /assets/uswds/img/circle-124.png
       alt: ''
     title: Never highlight anything without a goal.
     description: For anything you want to highlight here, understand what your users know now, and what activity or impression you want from them after they see it.
   - image:
-      src: /assets/img/circle.png
+      src: /assets/uswds/img/circle-124.png
       alt: ''
     title: Could also have 2 or 6.
-    description: In addition to your goal, find out your users’ goals. What do they want to know or do that supports your mission? Use these headings to show those.
+    description: In addition to your goal, find out your users’ goals. [What do they want to know](https://18f.gsa.gov/) or do that supports your mission? Use these headings to show those.
 ---
 
-## Section heading
+<h2>Section heading</h2>
+<p class="usa-font-lead">Everything up to this point should <a href="https://18f.gsa.gov/">help people understand</a> your agency or project: who you are, your goal or mission, and how you approach it. Use this section to encourage them to act. Describe why they should get in touch here, and use an active verb on the button below. “Get in touch,” “Learn more,” and so on.</p>
+<a class="usa-button usa-button-big" href="#">Call to action</a>
 
-Everything up to this point should help people understand your agency or project: who you are, your goal or mission, and how you approach it. Use this section to encourage them to act. Describe why they should get in touch here, and use an active verb on the button below. “Get in touch,” “Learn more,” and so on.
-{: .usa-font-lead }
-
-[Call to action](#){: .usa-button .usa-button-big }

--- a/demo/page.md
+++ b/demo/page.md
@@ -13,24 +13,25 @@ subnav:
 
 # Section one
 
-This is some content.
+This is some [content](https://18f.gsa.gov/).
 
 ## Section two
 
-This is some more content.
+This is some more [content](javascript:void(0);).
 
 ### Section three
 
-This is some more content.
+This is some more [content](#).
 
 #### Section four
 
-This is some more content.
+This is some more [content](https://18f.gsa.gov/).
 
 ##### Section five
 
-This is some more content.
+This is some more [content](https://18f.gsa.gov/).
 
 ###### Section six
 
-This is some more content.
+This is some more [content](https://18f.gsa.gov/).
+


### PR DESCRIPTION
Preview: https://federalist-proxy.app.cloud.gov/preview/18f/uswds-jekyll/sw-add-links/

Somehow the links in the content on the demo pages are no longer in master from this PR https://github.com/18F/uswds-jekyll/pull/136

I think the issues last friday with needed to redo the theming PR we omitted this work