### PR TITLE
Remove uniq filter from styles include

### DIFF
--- a/_includes/styles.html
+++ b/_includes/styles.html
@@ -5,8 +5,7 @@
   | push: _default_styles
   | push: site.styles
   | push: layout.styles
-  | push: page.styles
-  | uniq %}
+  | push: page.styles %}
 {% for _list in _styles %}{% for _style in _list %}
 <link rel="stylesheet"
   href="{{ _style.href | default: _style | relative_url }}"


### PR DESCRIPTION
The `uniq` filter is causing issues when styles are included using `href` and `media` in the `styles` array. Fixes https://github.com/18F/uswds-jekyll/issues/47