### PR TITLE
Removing grid from sidenav

### DIFF
--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -3,7 +3,7 @@ layout: page
 ---
 
 
-<aside class="usa-width-one-fourth usa-layout-docs-sidenav">
+<aside class="usa-layout-docs-sidenav sidenav">
   <ul class="usa-sidenav-list">
     {% for item in site.projects %}
       <li>

--- a/_layouts/team-member.html
+++ b/_layouts/team-member.html
@@ -3,7 +3,7 @@ layout: page
 ---
 
 
-<aside class="usa-width-one-fourth usa-layout-docs-sidenav">
+<aside class="usa-layout-docs-sidenav sidenav">
   <ul class="usa-sidenav-list">
     {% for item in site.team %}
       <li>


### PR DESCRIPTION
Removing `usa-width-one-fourth` as it is not needed for the sidenav 