### PR TITLE
Add ability to customize government TLD used in banner

### DIFF
--- a/_data/header.yml
+++ b/_data/header.yml
@@ -8,11 +8,10 @@
 # Comment out to the following line to hide.
 usa_banner: true
 
-# This theme is currently targeted at government websites on .gov and .mil.
 # This setting changes the TLD used as an argument for trust in banner.html.
-# If other options are ever added, it may be worth adding a JS determiner or
-#   other automated feature.
-government_tld: .gov
+# If options besides .mil and .gov are added, it may be worth adding a JS
+# determiner or other automated feature. If undefined, the default is .gov
+# government_tld: .mil
 
 # Defines the type of header.
 # Header types can be 'basic' or 'extended'.

--- a/_data/header.yml
+++ b/_data/header.yml
@@ -8,6 +8,12 @@
 # Comment out to the following line to hide.
 usa_banner: true
 
+# This theme is currently targeted at government websites on .gov and .mil.
+# This setting changes the TLD used as an argument for trust in banner.html.
+# If other options are ever added, it may be worth adding a JS determiner or
+#   other automated feature.
+government_tld: .gov
+
 # Defines the type of header.
 # Header types can be 'basic' or 'extended'.
 # Basic - https://components.designsystem.digital.gov/components/detail/header--basic.html

--- a/_includes/components/banner.html
+++ b/_includes/components/banner.html
@@ -7,7 +7,7 @@
     <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner">
       <div class="usa-banner-guidance-gov usa-width-one-half"> <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/uswds/img/icon-dot-gov.svg" alt="Dot gov">
         <div class="usa-media_block-body">
-          <p> <strong>The .gov means it’s official.</strong> <br> Federal government websites often end in .gov or .mil. Before sharing sensitive information, make sure you're on a federal government site. </p>
+          <p> <strong>The {{ header.government_tld }} means it’s official.</strong> <br> Federal government websites often end in .gov or .mil. Before sharing sensitive information, make sure you're on a federal government site. </p>
         </div>
       </div>
       <div class="usa-banner-guidance-ssl usa-width-one-half"> <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/uswds/img/icon-https.svg" alt="Https">

--- a/_includes/components/banner.html
+++ b/_includes/components/banner.html
@@ -7,7 +7,7 @@
     <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner">
       <div class="usa-banner-guidance-gov usa-width-one-half"> <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/uswds/img/icon-dot-gov.svg" alt="Dot gov">
         <div class="usa-media_block-body">
-          <p> <strong>The {{ header.government_tld }} means it’s official.</strong> <br> Federal government websites often end in .gov or .mil. Before sharing sensitive information, make sure you're on a federal government site. </p>
+          <p> <strong>The {{ header.government_tld | default: ".gov" }} means it’s official.</strong> <br> Federal government websites often end in .gov or .mil. Before sharing sensitive information, make sure you're on a federal government site. </p>
         </div>
       </div>
       <div class="usa-banner-guidance-ssl usa-width-one-half"> <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/uswds/img/icon-https.svg" alt="Https">


### PR DESCRIPTION
I'm working on some .mil websites, and want to correct an issue where the top banner argues the user should trust the website because it's a .gov.

This is one of the simpler solutions I could think of, and I note that if additional options are ever added one might want to add a JS based TLD determiner.

https://github.com/deptofdefense/code.mil/issues/182