### PR TITLE
use the page title from the frontmatter in the page itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,15 @@ shared by different components, such as the [header](#header) and
 [footer](#footer). See the documentation for those components for
 more info.
 
+### Page title
+
+Set each page's title in its frontmatter:
+
+```md
+---
+title: About us
+---
+```
 
 ### Page subnavigation
 

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -8,12 +8,8 @@ main:
 <aside class="usa-layout-docs-sidenav sidenav {% if page.sticky_sidenav %}usa-sticky-sidenav{% endif %}">
   {% include sidenav.html links=sidenav %}
 </aside>
+{% endif %}
 
 <div class="usa-layout-docs-main_content">
   {{ content }}
 </div>
-{% else %}
-<div class="usa-layout-docs-main_content">
-  {{ content }}
-</div>
-{% endif %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -11,5 +11,8 @@ main:
 {% endif %}
 
 <div class="usa-layout-docs-main_content">
+  {% if page.title %}
+  <h1>{{ page.title }}</h1>
+  {% endif %}
   {{ content }}
 </div>

--- a/demo/page.md
+++ b/demo/page.md
@@ -11,23 +11,23 @@ subnav:
     href: '#section-two'
 ---
 
-# Section one
+## Section one
 
 This is some [content](https://18f.gsa.gov/).
 
-## Section two
+### Section two
 
 This is some more [content](javascript:void(0);).
 
-### Section three
+#### Section three
 
 This is some more [content](#).
 
-#### Section four
+##### Section four
 
 This is some more [content](https://18f.gsa.gov/).
 
-##### Section five
+###### Section five
 
 This is some more [content](https://18f.gsa.gov/).
 


### PR DESCRIPTION
I was surprised that the title wasn't showing as an `<h1>` automatically, so this pull request adds it.

![documentation___this_is_the_site_title](https://user-images.githubusercontent.com/86842/40852458-8493f0b4-6598-11e8-9884-928256ba8190.png)

I suppose one could argue that not all users might want this, and/or that changing the behavior for current users would be unexpected... Thoughts?