### PR TITLE
allow edit_page to be the only footer option specified

### DIFF
--- a/_includes/components/footer--medium.html
+++ b/_includes/components/footer--medium.html
@@ -8,7 +8,7 @@
       </div>
     </div>
   {% endif %}
-  
+
   {% if footer.top %}
     <div class="usa-grid usa-footer-return-to-top">
       <a href="{{ footer.top.href | default: '#' }}">{{ footer.top.text | default: 'Return to top' }}</a>
@@ -39,7 +39,7 @@
   </div>
   {% endif %}
 
-  {% if footer.logos or footer.heading or footer.contact %}
+  {% if footer.logos or footer.heading or footer.contact or footer.edit_page %}
   <div class="usa-footer-secondary_section">
     <div class="usa-grid">
       <div class="usa-footer-logo usa-width-one-half">


### PR DESCRIPTION
No reason it should be dependent on the other options. Here's what it looks like (after the change) with a `footer.yml` config of

```yaml
type: medium
edit_page:
  text: Edit this page
```

⬇️

![screen shot 2018-07-03 at 1 19 43 am](https://user-images.githubusercontent.com/86842/42199959-31ceecf0-7e5f-11e8-95e7-c7dadf9d9957.png)
