### PR TITLE
Add Slim and Big footer variations

### DIFF
--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -1,8 +1,16 @@
 # This is the configuration for the site footer.
 
 # Configuration for type of footer.
-# Footer types can be only be medium at the moment
+# Footer types can be 'slim', 'medium', or 'big'.
+# https://designsystem.digital.gov/components/footers/
+#
+# Note that when using the big footer, you must change the value of `links`
+# below to 'footer_big' and edit that list in _data/navigation.html.
 type: medium
+
+# Configuration for which links show at the top of the footer.
+# this is a key into _data/navigation.yml
+links: footer
 
 # Configuration for "Return to top" link.
 # Customize with 'text' and 'href' properties.
@@ -20,10 +28,6 @@ top:
 # Configuration for "Last updated" date and time.
 # Uncomment the following line to show.
 # last_updated: true
-
-# Configuration for which links show at the top of the footer.
-# this is a key into _data/navigation.yml
-links: footer
 
 # Configuration for footer heading. (optional)
 heading: Name of agency

--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -3,14 +3,7 @@
 # Configuration for type of footer.
 # Footer types can be 'slim', 'medium', or 'big'.
 # https://designsystem.digital.gov/components/footers/
-#
-# Note that when using the big footer, you must change the value of `links`
-# below to 'footer_big' and edit that list in _data/navigation.html.
 type: medium
-
-# Configuration for which links show at the top of the footer.
-# this is a key into _data/navigation.yml
-links: footer
 
 # Configuration for "Return to top" link.
 # Customize with 'text' and 'href' properties.
@@ -28,6 +21,10 @@ top:
 # Configuration for "Last updated" date and time.
 # Uncomment the following line to show.
 # last_updated: true
+
+# Configuration for which links show at the top of the footer.
+# this is a key into _data/navigation.yml
+links: footer
 
 # Configuration for footer heading. (optional)
 heading: Name of agency

--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -26,6 +26,11 @@ top:
 # this is a key into _data/navigation.yml
 links: footer
 
+# Configuration for the big footer's email sign-up form.
+# Set to true to make the form visible.
+# Hooking it up to send the data somewhere is up to you :)
+big_footer_signup_form: false
+
 # Configuration for footer heading. (optional)
 heading: Name of agency
 

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -66,3 +66,40 @@ footer:
   - text: External link
     href: https://18f.gsa.gov
     external: true
+
+footer_big:
+  - text: Documentation
+    links:
+      - text: Overview
+        href: /docs/
+      - text: Secondary documentation page
+        href: /docs/two/
+      - text: Tertiary docs
+        href: /docs/three/
+  - text: Navigation section
+    links:
+      - text: Demo link A
+        href: /two/a/
+      - text: Demo link B
+        href: /two/b/
+      - text: Demo link C
+        href: /two/c/
+  - text: Referenced section
+    links:
+      - text: Demo link A
+        href: /three/a/
+      - text: Demo link B
+        href: /three/b/
+      - text: Demo link C
+        href: /three/c/
+  - text: External links
+    links:
+      - text: 18F
+        href: https://18f.gsa.gov
+        external: true
+      - text: Technology Transformation Service
+        href: https://join.tts.gsa.gov/
+        external: true
+      - text: code.gov
+        href: https://code.gov/
+        external: true

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -66,40 +66,40 @@ footer:
   - text: External link
     href: https://18f.gsa.gov
     external: true
-
-footer_big:
-  - text: Documentation
-    links:
-      - text: Overview
-        href: /docs/
-      - text: Secondary documentation page
-        href: /docs/two/
-      - text: Tertiary docs
-        href: /docs/three/
-  - text: Navigation section
-    links:
-      - text: Demo link A
-        href: /two/a/
-      - text: Demo link B
-        href: /two/b/
-      - text: Demo link C
-        href: /two/c/
-  - text: Referenced section
-    links:
-      - text: Demo link A
-        href: /three/a/
-      - text: Demo link B
-        href: /three/b/
-      - text: Demo link C
-        href: /three/c/
-  - text: External links
-    links:
-      - text: 18F
-        href: https://18f.gsa.gov
-        external: true
-      - text: Technology Transformation Service
-        href: https://join.tts.gsa.gov/
-        external: true
-      - text: code.gov
-        href: https://code.gov/
-        external: true
+# Uncomment the items below and comment the items above in the `footer` list
+# to use footer link columns in the 'big' footer style.
+  # - text: Documentation
+  #   links:
+  #     - text: Overview
+  #       href: /docs/
+  #     - text: Secondary documentation page
+  #       href: /docs/two/
+  #     - text: Tertiary docs
+  #       href: /docs/three/
+  # - text: Navigation section
+  #   links:
+  #     - text: Demo link A
+  #       href: /two/a/
+  #     - text: Demo link B
+  #       href: /two/b/
+  #     - text: Demo link C
+  #       href: /two/c/
+  # - text: Referenced section
+  #   links:
+  #     - text: Demo link A
+  #       href: /three/a/
+  #     - text: Demo link B
+  #       href: /three/b/
+  #     - text: Demo link C
+  #       href: /three/c/
+  # - text: External links
+  #   links:
+  #     - text: 18F
+  #       href: https://18f.gsa.gov
+  #       external: true
+  #     - text: Technology Transformation Service
+  #       href: https://join.tts.gsa.gov/
+  #       external: true
+  #     - text: code.gov
+  #       href: https://code.gov/
+  #       external: true

--- a/_includes/components/footer--big.html
+++ b/_includes/components/footer--big.html
@@ -24,7 +24,7 @@
     {% assign _size = _sizes[_size] | default: 'whole' %}
   <div class="usa-footer-primary-section">
     <div class="usa-grid">
-      <nav class="usa-footer-nav usa-width-two-thirds">
+      <nav class="usa-footer-nav{% if footer.big_footer_signup_form %} usa-width-two-thirds{% endif %}">
         {% for _topic in footer_links %}
         <ul class="usa-unstyled-list usa-width-one-{{ _size }} usa-footer-primary-content">
           <li class="usa-footer-primary-link">
@@ -39,7 +39,7 @@
         </ul>
         {% endfor %}
       </nav>
-
+      {% if footer.big_footer_signup_form %}
       <div class="usa-sign_up-block usa-width-one-third">
         <h3 class="usa-sign_up-header">Sign up</h3>
 
@@ -48,6 +48,7 @@
 
         <button type="submit">Sign up</button>
       </div>
+      {% endif %}
     </div>
   </div>
   {% endif %}

--- a/_includes/components/footer--big.html
+++ b/_includes/components/footer--big.html
@@ -1,0 +1,113 @@
+{% if footer %}
+<footer class="usa-footer usa-footer-big" role="contentinfo">
+
+  {% if footer.last_updated %}
+    <div class="usa-grid">
+      <div class="usa-width-one-whole">
+        <p>Last updated: {{ page.last_modified_at | date: '%B %d, %Y at %I:%M %p' }}</p>
+      </div>
+    </div>
+  {% endif %}
+
+  {% if footer.top %}
+    <div class="usa-grid usa-footer-return-to-top">
+      <a href="{{ footer.top.href | default: '#' }}">{{ footer.top.text | default: 'Return to top' }}</a>
+    </div>
+  {% endif %}
+
+
+
+  {% if footer.links %}
+    {% assign footer_links = site.data.navigation[footer.links] | default: footer.links %}
+    {% assign _sizes = 'whole half third fourth sixth' | split: ' ' %}
+    {% assign _size = footer_links.size | minus: 1 %}
+    {% assign _size = _sizes[_size] | default: 'whole' %}
+  <div class="usa-footer-primary-section">
+    <div class="usa-grid">
+      <nav class="usa-footer-nav usa-width-two-thirds">
+        {% for _topic in footer_links %}
+        <ul class="usa-unstyled-list usa-width-one-{{ _size }} usa-footer-primary-content">
+          <li class="usa-footer-primary-link">
+            <h4>{{ _topic.text }}</h4>
+          {% for _link in _topic.links %}
+          <li class="usa-footer-secondary-link">
+            <a href="{% if _link.external == true %}{{ _link.href }}{% else %}{{ _link.href | relative_url }}{% endif %}">
+              {{ _link.text }}
+            </a>
+          </li>
+          {% endfor %}
+        </ul>
+        {% endfor %}
+      </nav>
+
+      <div class="usa-sign_up-block usa-width-one-third">
+        <h3 class="usa-sign_up-header">Sign up</h3>
+
+        <label class="" for="email" id="">Your email address</label>
+        <input id="email" name="email" type="email">
+
+        <button type="submit">Sign up</button>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+
+  {% if footer.logos or footer.heading or footer.contact or footer.edit_page %}
+  <div class="usa-footer-secondary_section">
+    <div class="usa-grid">
+      <div class="usa-footer-logo usa-width-one-half">
+        {% if footer.logos %}
+          {% for logo in footer.logos -%}
+            {% if logo.url %}
+              <a href="{{ logo.url }}">
+            {% endif %}
+            <img class="usa-footer-big-logo-img" src="{% if logo.external %}{{ logo.src }}{% else %}{{ logo.src | relative_url }}{% endif %}" alt="{{ logo.alt }}"{% if logo.width %}width="{{ logo.width }}"{% endif %}{% if logo.height %}height="{{ logo.height }}"{% endif %}>
+            {% if logo.url %}
+              </a>
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+
+        {% if footer.heading %}
+        <h3 class="usa-footer-big-logo-heading">{{ footer.heading }}</h3>
+        {% endif %}
+      </div>
+
+      {% if footer.contact %}
+      <div class="usa-footer-contact-links usa-width-one-half">
+        {% assign social_links = site.data.footer.contact.social_links %}
+        {% if footer.contact.contact_links %}
+          {% for _link in social_links %}
+            <a class="usa-link-{{ _link.type | default: 'generic' }}" href="{% if _link.external == true %}{{ _link.href }}{% else %}{{ _link.href | relative_url }}{% endif %}">
+              <span>{{ _link.text }}</span>
+            </a>
+          {% endfor %}
+        {% endif %}
+        {% if footer.contact.heading %}
+          <h3 class="usa-footer-contact-heading">{{ footer.contact.heading }}</h3>
+          {% endif %}
+          {% if footer.contact.contact_links %}
+            <address>
+              {% assign contact_links = site.data.footer.contact.contact_links %}
+              {% for _link in contact_links %}
+                <div class="usa-footer-primary-content usa-footer-contact_info">
+                  <p>
+                    <a href="{% if _link.external == true %}{{ _link.href }}{% else %}{{ _link.href | relative_url }}{% endif %}">
+                      {{ _link.text }}
+                    </a>
+                  </p>
+                </div>
+              {% endfor %}
+            </address>
+        {% endif %}
+      {% endif %}
+      {% if footer.edit_page %}
+        <small><a href="https://github.com/{{ site.github.organization }}/{{ site.github.repository }}/edit/{{ site.github.default_branch }}/{{ page.path }}" class="usa-sidenav-edit" target="_blank">{{ footer.edit_page.text | default: 'Edit this page' }}</a></small>
+      {% endif %}
+      </div>
+    </div>
+  </div>
+  {% endif %}
+
+</footer>
+{% endif %}

--- a/_includes/components/footer--slim.html
+++ b/_includes/components/footer--slim.html
@@ -1,0 +1,89 @@
+{% if footer %}
+<footer class="usa-footer usa-footer-slim" role="contentinfo">
+
+  {% if footer.last_updated %}
+    <div class="usa-grid">
+      <div class="usa-width-one-whole">
+        <p>Last updated: {{ page.last_modified_at | date: '%B %d, %Y at %I:%M %p' }}</p>
+      </div>
+    </div>
+  {% endif %}
+
+  {% if footer.top %}
+    <div class="usa-grid usa-footer-return-to-top">
+      <a href="{{ footer.top.href | default: '#' }}">{{ footer.top.text | default: 'Return to top' }}</a>
+    </div>
+  {% endif %}
+
+
+
+  {% if footer.links %}
+    {% assign footer_links = site.data.navigation[footer.links] | default: footer.links %}
+    {% assign _sizes = 'whole half third fourth sixth' | split: ' ' %}
+    {% assign _size = footer_links.size | minus: 1 %}
+    {% assign _size = _sizes[_size] | default: 'whole' %}
+  <div class="usa-footer-primary-section">
+    <div class="usa-grid">
+      <nav class="usa-footer-nav{% if footer.contact.contact_links %} usa-width-two-thirds{% endif %}">
+        <ul class="usa-unstyled-list">
+          {% for _link in footer_links %}
+          <li class="usa-width-one-{{ _size }} usa-footer-primary-content">
+            <a class="usa-footer-primary-link" href="{% if _link.external == true %}{{ _link.href }}{% else %}{{ _link.href | relative_url }}{% endif %}">
+              {{ _link.text }}
+            </a>
+          </li>
+          {% endfor %}
+        </ul>
+      </nav>
+    {% if footer.contact.contact_links %}
+      <address>
+        <div class="usa-width-one-third">
+          {% assign contact_links = site.data.footer.contact.contact_links %}
+          {% for _link in contact_links %}
+            <div class="usa-footer-primary-content usa-footer-contact_info">
+              <p>
+                <a href="{% if _link.external == true %}{{ _link.href }}{% else %}{{ _link.href | relative_url }}{% endif %}">
+                  {{ _link.text }}
+                </a>
+              </p>
+            </div>
+          {% endfor %}
+        </div>
+      </address>
+    {% endif %}
+    </div>
+  </div>
+  {% endif %}
+
+  {% if footer.logos or footer.edit_page %}
+  <div class="usa-footer-secondary_section">
+    <div class="usa-grid">
+      <div class="usa-footer-logo usa-width-one-half">
+        {% if footer.logos %}
+          {% for logo in footer.logos -%}
+            {% if logo.url %}
+              <a href="{{ logo.url }}">
+            {% endif %}
+            <img class="usa-footer-slim-logo-img" src="{% if logo.external %}{{ logo.src }}{% else %}{{ logo.src | relative_url }}{% endif %}" alt="{{ logo.alt }}"{% if logo.width %}width="{{ logo.width }}"{% endif %}{% if logo.height %}height="{{ logo.height }}"{% endif %}>
+            {% if logo.url %}
+              </a>
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+
+        {% if footer.heading %}
+        <h3 class="usa-footer-slim-logo-heading">{{ footer.heading }}</h3>
+        {% endif %}
+      </div>
+
+      {% if footer.edit_page %}
+      <div class="usa-footer-contact-links usa-width-one-half align-right">
+        <small><a href="https://github.com/{{ site.github.organization }}/{{ site.github.repository }}/edit/{{ site.github.default_branch }}/{{ page.path }}" class="usa-sidenav-edit" target="_blank">{{ footer.edit_page.text | default: 'Edit this page' }}</a></small>
+      </div>
+      {% endif %}
+    </div>
+  </div>
+  {% endif %}
+
+</footer>
+{% endif %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,3 +1,9 @@
 {% assign footer = site.data.footer %}
 
-{% include components/footer--medium.html %}
+{% if footer.type == 'slim' %}
+  {% include components/footer--slim.html %}
+{% elsif footer.type == 'medium' %}
+  {% include components/footer--medium.html %}
+{% elsif footer.type == 'big' %}
+  {% include components/footer--big.html %}
+{% endif %}


### PR DESCRIPTION
Closes #53 

This PR introduces the ability to use the Slim and Big variations for the footer. I modeled this off of the way that header variations are selected.

I'm not positive if it's the best way to do it, but I added a new group in `_data/navigation.yml` for the Big footer's topic headers and links. I don't love that it necessitates editing a second value in `_data/footer.yml`, but hopefully the comment I left about it and moving that `links` value right up under it makes it clear enough for people. Let me know if you'd like me to try something different.

Happy Hacktoberfest! 🎃 