### PR TITLE
correct SASS customization documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,8 +446,8 @@ the USWDS source files:
 
 // at the very least, you should set the USWDS font and image paths
 // to the correct paths relative to assets/main.css, like so:
-$font-path: 'uswds/fonts';
-$image-path: 'uswds/img';
+$font-path: '../uswds/fonts';
+$image-path: '../uswds/img';
 
 @import 'uswds/all';
 ```

--- a/README.md
+++ b/README.md
@@ -435,29 +435,22 @@ and layouts.
 
 ### Customizing with Sass
 
-1. Create a [Sass][] (or SCSS) entry point that sets variables and then imports
-   the USWDS source files:
+Create a [Sass][] (or SCSS) entry point that sets variables and then imports
+the USWDS source files:
 
-    ```scss
-    ---
-    # assets/main.scss
-    ---
-    // set your variables or @import them here.
+```scss
+---
+# assets/css/main.scss
+---
+// set your variables or @import them here.
 
-    // at the very least, you should set the USWDS font and image paths
-    // to the correct paths relative to assets/main.css, like so:
-    $font-path: 'uswds/fonts';
-    $image-path: 'uswds/img';
+// at the very least, you should set the USWDS font and image paths
+// to the correct paths relative to assets/main.css, like so:
+$font-path: 'uswds/fonts';
+$image-path: 'uswds/img';
 
-    @import 'uswds/all';
-    ```
-
-1. Change the path to your site's default stylesheet in your `_config.yml`:
-
-    ```yml
-    styles:
-      - /assets/main.css
-    ```
+@import 'uswds/all';
+```
 
 All of the USWDS [SCSS source files](https://github.com/uswds/uswds/tree/master/src/stylesheets)
 are placed in the [_sass/uswds](_sass/uswds) directory and are available as


### PR DESCRIPTION
Setting the `styles` in the `_config.yml` doesn't stop the site from loading the default stylesheet, so just have that path match.

https://github.com/18F/uswds-jekyll/blob/9063de07ce09e308437eefba8f8d45f77ea2a9e2/_includes/styles.html#L2-L6

I suggest viewing the diff [ignoring whitespace](https://github.com/18F/uswds-jekyll/pull/172/files?w=1).