### PR TITLE
fix display of the main content in the homepage template

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,3 +1,7 @@
 ---
 layout: default
+main:
+  class: usa-grid usa-section usa-content usa-layout-docs
 ---
+
+{{ content }}


### PR DESCRIPTION
This whole chunk had been missing from the demo site, meaning users weren't able to include any `<main>` content on their homepages using that template.

![Screen Shot 2019-04-24 at 1 28 26 AM](https://user-images.githubusercontent.com/86842/56634549-632f0500-6630-11e9-84b7-c339414a3f1c.png)
