### PR TITLE
github_info instead of github to support remote_theme on GitHub Pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ description: This is the site description.
 
 # GitHub information
 # This is used for adding an edit this page link to the footer
-github:
+github_info:
   organization: 18F
   repository: uswds-jekyll
   default_branch: master

--- a/_includes/components/footer--big.html
+++ b/_includes/components/footer--big.html
@@ -103,7 +103,7 @@
         {% endif %}
       {% endif %}
       {% if footer.edit_page %}
-        <small><a href="https://github.com/{{ site.github_info.organization }}/{{ site.github_info.repository }}/edit/{{ site.github_info.default_branch }}/{{ page.path }}" class="usa-sidenav-edit" target="_blank">{{ footer.edit_page.text | default: 'Edit this page' }}</a></small>
+        {% include components/github-edit.html footer=footer path=page.path %}
       {% endif %}
       </div>
     </div>

--- a/_includes/components/footer--big.html
+++ b/_includes/components/footer--big.html
@@ -103,7 +103,7 @@
         {% endif %}
       {% endif %}
       {% if footer.edit_page %}
-        <small><a href="https://github.com/{{ site.github.organization }}/{{ site.github.repository }}/edit/{{ site.github.default_branch }}/{{ page.path }}" class="usa-sidenav-edit" target="_blank">{{ footer.edit_page.text | default: 'Edit this page' }}</a></small>
+        <small><a href="https://github.com/{{ site.github_info.organization }}/{{ site.github_info.repository }}/edit/{{ site.github_info.default_branch }}/{{ page.path }}" class="usa-sidenav-edit" target="_blank">{{ footer.edit_page.text | default: 'Edit this page' }}</a></small>
       {% endif %}
       </div>
     </div>

--- a/_includes/components/footer--medium.html
+++ b/_includes/components/footer--medium.html
@@ -89,7 +89,7 @@
         {% endif %}
       {% endif %}
       {% if footer.edit_page %}
-        <small><a href="https://github.com/{{ site.github_info.organization }}/{{ site.github_info.repository }}/edit/{{ site.github_info.default_branch }}/{{ page.path }}" class="usa-sidenav-edit" target="_blank">{{ footer.edit_page.text | default: 'Edit this page' }}</a></small>
+        {% include components/github-edit.html footer=footer path=page.path %}
       {% endif %}
       </div>
     </div>

--- a/_includes/components/footer--medium.html
+++ b/_includes/components/footer--medium.html
@@ -89,7 +89,7 @@
         {% endif %}
       {% endif %}
       {% if footer.edit_page %}
-        <small><a href="https://github.com/{{ site.github.organization }}/{{ site.github.repository }}/edit/{{ site.github.default_branch }}/{{ page.path }}" class="usa-sidenav-edit" target="_blank">{{ footer.edit_page.text | default: 'Edit this page' }}</a></small>
+        <small><a href="https://github.com/{{ site.github_info.organization }}/{{ site.github_info.repository }}/edit/{{ site.github_info.default_branch }}/{{ page.path }}" class="usa-sidenav-edit" target="_blank">{{ footer.edit_page.text | default: 'Edit this page' }}</a></small>
       {% endif %}
       </div>
     </div>

--- a/_includes/components/footer--slim.html
+++ b/_includes/components/footer--slim.html
@@ -78,7 +78,7 @@
 
       {% if footer.edit_page %}
       <div class="usa-footer-contact-links usa-width-one-half align-right">
-        <small><a href="https://github.com/{{ site.github_info.organization }}/{{ site.github_info.repository }}/edit/{{ site.github_info.default_branch }}/{{ page.path }}" class="usa-sidenav-edit" target="_blank">{{ footer.edit_page.text | default: 'Edit this page' }}</a></small>
+        {% include components/github-edit.html footer=footer path=page.path %}
       </div>
       {% endif %}
     </div>

--- a/_includes/components/footer--slim.html
+++ b/_includes/components/footer--slim.html
@@ -78,7 +78,7 @@
 
       {% if footer.edit_page %}
       <div class="usa-footer-contact-links usa-width-one-half align-right">
-        <small><a href="https://github.com/{{ site.github.organization }}/{{ site.github.repository }}/edit/{{ site.github.default_branch }}/{{ page.path }}" class="usa-sidenav-edit" target="_blank">{{ footer.edit_page.text | default: 'Edit this page' }}</a></small>
+        <small><a href="https://github.com/{{ site.github_info.organization }}/{{ site.github_info.repository }}/edit/{{ site.github_info.default_branch }}/{{ page.path }}" class="usa-sidenav-edit" target="_blank">{{ footer.edit_page.text | default: 'Edit this page' }}</a></small>
       </div>
       {% endif %}
     </div>

--- a/_includes/components/github-edit.html
+++ b/_includes/components/github-edit.html
@@ -1,0 +1,3 @@
+{% assign github_info = site.github_info | default: site.github %}
+{% assign edit_link_text = include.footer.edit_page.text | default: 'Edit this page' %}
+<small><a href="https://github.com/{{ github_info.organization }}/{{ github_info.repository }}/edit/{{ github_info.default_branch }}/{{ include.path }}" class="usa-sidenav-edit" target="_blank">{{ edit_link_text }}</a></small>


### PR DESCRIPTION
This works around a weird problem, where the presence of a "github" key in the _config.yml file prevents remote_theme from working on GitHub pages. More detail [here](https://github.com/benbalter/jekyll-remote-theme/issues/32). The workaround here is to use "github_info" instead.

~~This is obviously a breaking change (albeit not so bad), but I don't see any way to maintain backwards compatibility and still fix the problem.~~ Correction: figured out a way to keep backwards-compatibility.

This also splits the link into a sub-component, to avoid repetition. This makes it easier for sites to override this link, in case they want to link to something like Prose.io instead of Github.com.

Fixes #174 