### PR TITLE
migrate from Google Analytics' analytics.js to gtag.js

### DIFF
--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,16 +1,12 @@
 {% if site.google_analytics_ua %}
 <!-- Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics_ua }}"></script>
 <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-  ga('create', '{{ site.google_analytics_ua }}', 'auto');
+  window.dataLayer = window.dataLayer || [];
+  function gtag() { dataLayer.push(arguments); }
+  gtag('js', new Date());
 
-  // anonymize user IPs (chops off the last IP triplet)
-  ga('set', 'anonymizeIp', true);
-  ga('set', 'forceSSL', true);
-  ga('send', 'pageview');
+  gtag('config', '{{ site.google_analytics_ua }}', { 'anonymize_ip': true, 'forceSSL': true });
 </script>
 {% endif %}
 

--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -6,6 +6,7 @@
   function gtag() { dataLayer.push(arguments); }
   gtag('js', new Date());
 
+  // `forceSSL` was used for analytics.js (the older Google Analytics script). It isn't documented for gtag.js, but the term occurs in the gtag.js code; figure it doesn't hurt to leave it in. -@afeld, 5/29/19
   gtag('config', '{{ site.google_analytics_ua }}', { 'anonymize_ip': true, 'forceSSL': true });
 </script>
 {% endif %}


### PR DESCRIPTION
Per their setup page, "Global Site Tag (gtag.js) and Google Tag Manager are the recommended tracking methods for new implementations." Additional bonus is that it can be used to verify sites for Google Search Console.

![Screen Shot 2019-05-29 at 1 27 02 AM](https://user-images.githubusercontent.com/86842/58531606-ea801300-81b0-11e9-8452-05f4788dfa90.png)

Not sure if there are downsides.

https://developers.google.com/analytics/devguides/collection/gtagjs/migration