### PR TITLE
search fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ The default colors and fonts can be configured in the `_data/theme.yml` file.
 Before configuring your search you will need to create a search.gov account and set up your website
 with search.gov.
 
-After setting up your site on search.gov you can then add your `site handle` to the `config.yml`.
+After setting up your site on search.gov you can then add your `search_site_handle` to the `config.yml`.
 
 ### Analytics
 

--- a/_includes/components/header.html
+++ b/_includes/components/header.html
@@ -96,7 +96,7 @@
           {% assign _secondary = header.secondary %}
           <div class="usa-nav-secondary">
             {% if site.search_site_handle  %}
-              {% include components/search.html extra_class="usa-sr-only" %}
+              {% include components/search.html %}
             {% endif %}
             <ul class="usa-unstyled-list usa-nav-secondary-links">
               {% if site.search_site_handle %}

--- a/_includes/components/header.html
+++ b/_includes/components/header.html
@@ -88,19 +88,7 @@
         {% if header.type == 'basic' or header.type == 'basic-mega' %}
           {% assign _secondary = header.secondary %}
           {% if site.search_site_handle  %}
-            <form accept-charset="UTF-8" action="https://search.usa.gov/search" id="search_form" method="get" class="usa-search usa-search-small js-search-form">
-              <div style="margin:0;padding:0;display:inline">
-                <input name="utf8" type="hidden" value="&#x2713;" />
-              </div>
-              <input id="affiliate" name="affiliate" type="hidden" value="{{ site.search_site_handle }}" />
-              <div role="search">
-                <label for="query" class="usa-sr-only">Enter Search Term(s):</label>
-                <input autocomplete="off" class="usagov-search-autocomplete" id="query" name="query" type="search" />
-                <button type="submit" name="commit">
-                  <span class="usa-sr-only">Search</span>
-                </button>
-              </div>
-            </form>
+            {% include components/search.html %}
           {% endif %}
           {% endif %}
 
@@ -108,19 +96,7 @@
           {% assign _secondary = header.secondary %}
           <div class="usa-nav-secondary">
             {% if site.search_site_handle  %}
-              <form accept-charset="UTF-8" action="https://search.usa.gov/search" id="search_form" method="get" class="usa-search usa-search-small js-search-form usa-sr-only">
-                <div style="margin:0;padding:0;display:inline">
-                  <input name="utf8" type="hidden" value="&#x2713;" />
-                </div>
-                <input id="affiliate" name="affiliate" type="hidden" value="{{ site.search_site_handle }}" />
-                <div role="search">
-                  <label for="query" class="usa-sr-only">Enter Search Term(s):</label>
-                  <input autocomplete="off" class="usagov-search-autocomplete" id="query" name="query" type="search" />
-                  <button type="submit" name="commit">
-                    <span class="usa-sr-only">Search</span>
-                  </button>
-                </div>
-              </form>
+              {% include components/search.html extra_class="usa-sr-only" %}
             {% endif %}
             <ul class="usa-unstyled-list usa-nav-secondary-links">
               {% if site.search_site_handle %}

--- a/_includes/components/search.html
+++ b/_includes/components/search.html
@@ -1,0 +1,13 @@
+<form accept-charset="UTF-8" action="https://search.usa.gov/search" class="usa-search usa-search-small js-search-form {{ include.extra_class }}" id="search_form" method="get">
+  <div style="margin:0;padding:0;display:inline">
+    <input name="utf8" type="hidden" value="&#x2713;"/>
+  </div>
+  <input id="affiliate" name="affiliate" type="hidden" value="{{ site.search_site_handle }}"/>
+  <div role="search">
+    <label class="usa-sr-only" for="query">Enter Search Term(s):</label>
+    <input autocomplete="off" class="usagov-search-autocomplete" id="query" name="query" type="search"/>
+    <button name="commit" type="submit">
+      <span class="usa-sr-only">Search</span>
+    </button>
+  </div>
+</form>

--- a/_includes/components/search.html
+++ b/_includes/components/search.html
@@ -1,12 +1,10 @@
-<form accept-charset="UTF-8" action="https://search.usa.gov/search" class="usa-search usa-search-small js-search-form {{ include.extra_class }}" id="search_form" method="get">
-  <div style="margin:0;padding:0;display:inline">
-    <input name="utf8" type="hidden" value="&#x2713;"/>
-  </div>
+<form accept-charset="UTF-8" action="https://search.usa.gov/search" class="usa-search usa-search-small js-search-form" method="get">
+  <input name="utf8" type="hidden" value="&#x2713;"/>
   <input id="affiliate" name="affiliate" type="hidden" value="{{ site.search_site_handle }}"/>
   <div role="search">
     <label class="usa-sr-only" for="query">Enter Search Term(s):</label>
     <input autocomplete="off" class="usagov-search-autocomplete" id="query" name="query" type="search"/>
-    <button name="commit" type="submit">
+    <button type="submit">
       <span class="usa-sr-only">Search</span>
     </button>
   </div>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -24,10 +24,10 @@
 {% endfor %}{% endfor %}
 
 
-{% if site.search %}
+{% if site.search_site_handle %}
 <script type="text/javascript">
 //<![CDATA[
-      var usasearch_config = { siteHandle:"{{ site.search.site_handle }}" };
+      var usasearch_config = { siteHandle:"{{ site.search_site_handle }}" };
 
       var script = document.createElement("script");
       script.type = "text/javascript";


### PR DESCRIPTION
- Made the search configuration key consistent
- ~~Got rid of the search.gov autocomplete - didn't seem to be showing up anyway~~
- Fixed the search box not appearing when using the `extended` headers

**Before:**

![before](https://user-images.githubusercontent.com/86842/62998465-a01a4400-be39-11e9-940e-e63ef1f71169.gif)

**After:**

![after (1)](https://user-images.githubusercontent.com/86842/62998464-a01a4400-be39-11e9-9f6d-f371d67786f6.gif)

Discovered while working on https://github.com/18F/handbook/pull/1358.