### PR TITLE
proof of concept: automatically generate subnav

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,5 @@ gemspec :name => 'uswds-jekyll'
 
 group :jekyll_plugins do
   gem 'jekyll-last-modified-at'
+  gem 'jekyll-toc'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,8 @@ GEM
       posix-spawn (~> 0.3.9)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
+    jekyll-toc (0.12.2)
+      nokogiri (~> 1.9)
     jekyll-watch (2.1.2)
       listen (~> 3.0)
     kramdown (1.17.0)
@@ -47,6 +49,9 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
     mercenary (0.3.6)
+    mini_portile2 (2.4.0)
+    nokogiri (1.10.4)
+      mini_portile2 (~> 2.4.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     posix-spawn (0.3.13)
@@ -70,8 +75,9 @@ PLATFORMS
 DEPENDENCIES
   bundler
   jekyll-last-modified-at
+  jekyll-toc
   rake
   uswds-jekyll!
 
 BUNDLED WITH
-   1.16.6
+   1.17.3

--- a/README.md
+++ b/README.md
@@ -195,16 +195,11 @@ title: About us
 ### Page subnavigation
 
 If you're using the [page layout](#layout-page), each page may declare its own
-side navigation and subnavigation in its [front matter]:
+side navigation:
 
 ```md
 ---
 sidenav: documentation
-subnav:
-  - text: Section one
-    href: '#section-one'
-  - text: Section two
-    href: '#section-two
 ---
 ## Section one
 
@@ -215,22 +210,14 @@ As with the [header](#header) and [footer](#footer), the `sidenav` field may
 either reference a common [navigation list](#navigation) from
 `_data/navigation.yml` (recommended) or be a literal list of links.
 
-The `subnav` field should be used to link to sections _within_ the current
-page, because links to other pages will cause the linking page's side
-navigation to collapse when visited.
-
+The subnavigation will be shown automatically for the current page. See
+[customization options](https://github.com/toshimaru/jekyll-toc#customization).
 
 `sidenav` is a key _into_ `_data/navigation.yml`. See the [navigation](#navigation) docs for more info.
 
 A page's "current" or "active" state in the sidenav is
 determined by whether a link's `href` matches `page.url` or
 `page.permalink` for each page being rendered.
-
-`subnav` is a list of links to display on this page under its own link in the side navigation.
-
-**Note that subnav link hrefs are not prefixed with
-`site.baseurl`** because this breaks hash links prefixed with
-`#`.
 
 **Pro tip:** Unless your Jekyll configuration specifies otherwise, the default
 Markdown formatter (Kramdown) will automatically generate predictable `id`

--- a/_config.yml
+++ b/_config.yml
@@ -40,3 +40,9 @@ github_info:
 # Compress Sass
 sass:
   style: compressed
+
+toc:
+  min_level: 2
+  max_level: 3
+  list_class: usa-sidenav-sub_list
+  sublist_class: usa-sidenav-sub_list

--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -12,10 +12,8 @@
          {% if link.class %}class="{{ link.class }}" {% endif %} >
          {{ link.text }}
       </a>
-      {% if _current and page.subnav %}
-      <ul class="usa-sidenav-sub_list">
-        {% include subnav.html links=page.subnav %}
-      </ul>
+      {% if _current %}
+      {{ content | toc_only }}
       {% endif %}
     </li>
     {% endfor %}

--- a/_includes/subnav.html
+++ b/_includes/subnav.html
@@ -1,5 +1,0 @@
-{% for link in include.links %}
-  <li>
-    <a href="{% if link.external %}{{ link.href }}{% else %}{{ link.href }}{% endif %}" {% if link.class %} class="{{ link.class }}" {% endif %}>{{ link.text }} {{ link.class }}</a>
-  </li>
-{% endfor %}

--- a/demo/page.md
+++ b/demo/page.md
@@ -5,11 +5,7 @@ permalink: /docs/
 
 layout: post
 sidenav: docs
-subnav:
-  - text: Section one
-    href: '#section-one'
-  - text: Section two
-    href: '#section-two'
+toc: true
 ---
 
 ## Section one


### PR DESCRIPTION
...rather than having to create by hand. Open questions:

- I personally think constructing tables of contents by hand is an anti-pattern. Do others like this idea of automatically generating them?
- This is a breaking change, as the `subnav` page variable is no longer supported. While , do we want to make it backwards-compatible?
- The subnav only shows up if the page has a sidenav. Open to changing that?
- Do we want to include the gem by default? Do we enable by default on all pages?