### PR TITLE
Add strip_html filter to meta title

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-<title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+<title>{% if page.title %}{{ page.title | strip_html }} | {% endif %}{{ site.title }}</title>
 
 {% assign description = page.description | default: site.description %}
 {% if description %}


### PR DESCRIPTION
Fixes rendering of html tags in meta title tag, such as in this example:

![Get set up to travel for tts with em html tags surrounding before GSA onboarding](https://user-images.githubusercontent.com/32855580/75205666-3c969a80-5729-11ea-822c-11ae316d5df8.png)

