### PR TITLE
Remove incorrect examples in sidenav config

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -45,16 +45,6 @@ secondary:
 docs:
   - text: Sidenav Documentation
     href: /docs/
-  - text: Sidenav Navigation section
-    links:
-      - text: Demo link A
-        href: /two/a/
-      - text: Demo link B
-        href: /two/b/
-      - text: Demo link C
-        href: /two/c/
-  - text: Sidenav Referenced section
-    links: footer
   - text: Sidenav External link
     href: https://18f.gsa.gov
     external: true


### PR DESCRIPTION
I believe these incorrect example entries were unintentionally added in 9a1eac135fb282d08339aba76388e7419584b700. The sidenav doesn't support nested links or references to other named navigation lists.