### PR TITLE
Replace deprecated variables and rules

### DIFF
--- a/_sass/uswds/components/_header.scss
+++ b/_sass/uswds/components/_header.scss
@@ -17,7 +17,7 @@
       height: units(2);
       margin-right: units(1);
 
-      @media($theme-header-min-width) {
+      @include at-media($theme-header-min-width) {
         margin-top: 0;
         height: units(3);
       }

--- a/_sass/uswds/components/_nav-buttons.scss
+++ b/_sass/uswds/components/_nav-buttons.scss
@@ -1,17 +1,17 @@
 .usa-header,
 .usa-sidenav-list {
-  @media($theme-header-min-width) {
+  @media ($theme-header-min-width) {
     .usa-button {
       margin: 0;
       width: auto;
     }
   }
   .usa-button {
-    color: $color-white;
+    color: color("white");
     padding: units(1.5);
     &:hover {
-      background-color: color('primary-dark');
-      color: $color-white;
+      background-color: color("primary-dark");
+      color: color("white");
       text-decoration: none;
     }
   }

--- a/_sass/uswds/components/_nav-buttons.scss
+++ b/_sass/uswds/components/_nav-buttons.scss
@@ -1,6 +1,6 @@
 .usa-header,
 .usa-sidenav-list {
-  @media ($theme-header-min-width) {
+  @include at-media($theme-header-min-width) {
     .usa-button {
       margin: 0;
       width: auto;


### PR DESCRIPTION
Fixes a bug called out in the USWDS Public Slack.

- Removes the `$color-white` variable from the code and replaces it with the proper color token.
- Replaces `@media` with the USWDS `@include at-media()`