### PR TITLE
use default value for the sidenav breakpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,9 +536,6 @@ See [this example pull request](https://github.com/18F/before-you-ship/pull/458)
    --> footer.yml
    type: [slim | default | big]
 
-   --> navigation.yml
-   sidenav-breakpoint: {{ breakpoint_token }}
-
    --> theme.yml (examples)
    colors:
      usa-banner:

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,7 +1,5 @@
 # This is the configuration for the site navigation.
 
-sidenav-breakpoint: 'desktop'
-
 # This file defines the structure of various named navigational
 # listings, any of which can be used (with some caveats) as the
 # links in your header, footer, and per-page side navigation.
@@ -49,9 +47,9 @@ docs:
     href: https://18f.gsa.gov
     external: true
 
-footer:
 # Uncomment the 'links' sections below to use footer link columns
 # with the 'big' footer style.
+footer:
   - text: Documentation
     href: /docs/
     links:

--- a/_sass/uswds/components/_side-nav.scss
+++ b/_sass/uswds/components/_side-nav.scss
@@ -33,16 +33,14 @@
   }
 }
 
-@if variable-exists(theme-sidenav-breakpoint) {
-  @include at-media($theme-sidenav-breakpoint){
-    .usa-layout-docs__sidenav {
-      @include u-flex(3);
-      order: 1;
-      padding-top: 0;
-    }
-    .usa-layout-docs__main {
-      @include u-flex(9);
-      order: 2;
-    }
+@include at-media($theme-sidenav-breakpoint){
+  .usa-layout-docs__sidenav {
+    @include u-flex(3);
+    order: 1;
+    padding-top: 0;
+  }
+  .usa-layout-docs__main {
+    @include u-flex(9);
+    order: 2;
   }
 }

--- a/assets/css/uswds-theme.scss
+++ b/assets/css/uswds-theme.scss
@@ -32,9 +32,7 @@
   @import 'uswds/components/site-width';
 {% endif %}
 
-{% if site.data.navigation.sidenav-breakpoint %}
-  $theme-sidenav-breakpoint: '{{ site.data.navigation.sidenav-breakpoint }}';
-{% endif %}
+$theme-sidenav-breakpoint: '{{ site.data.navigation.sidenav-breakpoint | default: "desktop" }}';
 
 // Banner colors
 {% assign colors_banner = site.data.theme.colors.usa-banner %}


### PR DESCRIPTION
Don't think we want/expect folks to override it anyway. Easiest to [review ignoring whitespace](https://github.com/18F/uswds-jekyll/pull/213/files?diff=unified&w=1).