### PR TITLE
include mini_racer as a dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     uswds-jekyll (5.2.0)
       jekyll (>= 4.0, < 5)
       jekyll-autoprefixer
+      mini_racer
 
 GEM
   remote: https://rubygems.org/
@@ -52,11 +53,14 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
+    libv8 (8.4.255.0)
     liquid (4.0.3)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
+    mini_racer (0.3.1)
+      libv8 (~> 8.4.255)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     posix-spawn (0.3.15)

--- a/uswds-jekyll.gemspec
+++ b/uswds-jekyll.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "jekyll", ">= 4.0", "< 5"
   s.add_runtime_dependency "jekyll-autoprefixer"
+  # while not strictly required — another runtime from https://github.com/rails/execjs#readme could be used for autoprefixer — simpler to require this by default
+  s.add_runtime_dependency "mini_racer"
 
   s.add_development_dependency "bundler"
   s.add_development_dependency "rake"


### PR DESCRIPTION
Sites using uswds-jekyll 5.2.0+ require autoprefixer, which requires execjs, which require a JavaScript runtime, which requires installation on the user side to avoid [the "Could not find a JavaScript runtime" error](https://app.circleci.com/pipelines/github/18F/before-you-ship/69/workflows/c0eecfaa-cf95-4826-b6af-f7bc0f619f20/jobs/285). Rather than them have to make decisions or troubleshoot, this makes it simpler by including a (possibly redundant) JS runtime in the theme itself. This will automatically get pulled in as a sub-dependency on sites that use the theme, making the upgrade to 5.2.0+ seamless.