### PR TITLE
Add touchpoints to the gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,10 @@ You can add DAP to your site by uncommenting the `dap_agency` line and, if need 
 # dap_subagency: TTS
 ```
 
+### Feedback form
+
+To add a user feedback form, create a new survey through [Touchpoints](https://touchpoints.digital.gov/) and add the ID via the `touchpoints_form_id` key in `_config.yml`.
+
 ### Last modified date
 
 To show the last date a page was last modified by:

--- a/_config.yml
+++ b/_config.yml
@@ -35,6 +35,8 @@ private_eye: true
 
 # search_site_handle: searchgov-site-handle
 
+# touchpoints_form_id:
+
 # Configuration for projects and team collections
 # See https://jekyllrb.com/docs/collections/ for more information about collections.
 # collections:

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -55,7 +55,7 @@
 
       var script = document.createElement("script");
       script.type = "text/javascript";
-      script.src = `https://touchpoints.app.cloud.gov/touchpoints/${touchpoints_config}/js`;
+      script.src = `https://touchpoints.app.cloud.gov/touchpoints/${touchpoints_config.siteHandle}/js`;
       script.async = true;
       document.getElementsByTagName("head")[0].appendChild(script);
 

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -45,4 +45,19 @@
 
 //]]>
 </script>
+
+{% if site.touchpoints_form_id %}
+<script type="text/javascript">
+//<![CDATA[
+      var touchpoints_config = { siteHandle:"{{ site.touchpoints_form_id }}" };
+
+      var script = document.createElement("script");
+      script.type = "text/javascript";
+      script.src = `https://touchpoints.app.cloud.gov/touchpoints/${touchpoints_config}/js`;
+      script.async = true;
+      document.getElementsByTagName("head")[0].appendChild(script);
+
+//]]>
+</script>
+
 {% endif %}

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -45,6 +45,8 @@
 
 //]]>
 </script>
+{% endif %}
+
 
 {% if site.touchpoints_form_id %}
 <script type="text/javascript">


### PR DESCRIPTION
Touchpoints is a cool tool that lets federal agencies collect feedback from the public. This PR would allow a user to add a touchpoints_form_id to the _config.yml and automatically add the modal script from touchpoints. I.e.,

```
# touchpoints
touchpoints_form_id: abcd1234
```
