### PR TITLE
Default the gov-banner to hidden

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    uswds-jekyll (5.4.0)
+    uswds-jekyll (5.5.0)
       jekyll (>= 4.0, < 5)
       jekyll-autoprefixer
       mini_racer

--- a/_includes/components/banner.html
+++ b/_includes/components/banner.html
@@ -15,7 +15,7 @@
         </button>
       </div>
     </header>
-    <div class="usa-banner__content usa-accordion__content" id="gov-banner">
+    <div class="usa-banner__content usa-accordion__content" id="gov-banner" hidden>
       <div class="grid-row grid-gap-lg">
         <div class="usa-banner__guidance tablet:grid-col-6">
           <img class="usa-banner__icon usa-media-block__img" src="{{ site.baseurl }}/assets/uswds/img/icon-dot-gov.svg" role="img" alt="Dot gov">

--- a/_includes/components/banner.html
+++ b/_includes/components/banner.html
@@ -19,7 +19,7 @@
       <script type="text/javascript">
         // Hide the gov banner immediately rather than waiting for external JS
         // sources to load and execute.
-        document.getElementById("gov-banner").setAttribute("hidden");
+        document.getElementById("gov-banner").setAttribute("hidden", "");
       </script>
       <div class="grid-row grid-gap-lg">
         <div class="usa-banner__guidance tablet:grid-col-6">

--- a/_includes/components/banner.html
+++ b/_includes/components/banner.html
@@ -15,7 +15,12 @@
         </button>
       </div>
     </header>
-    <div class="usa-banner__content usa-accordion__content" id="gov-banner" hidden>
+    <div class="usa-banner__content usa-accordion__content" id="gov-banner">
+      <script type="text/javascript">
+        // Hide the gov banner immediately rather than waiting for external JS
+        // sources to load and execute.
+        document.getElementById("gov-banner").setAttribute("hidden");
+      </script>
       <div class="grid-row grid-gap-lg">
         <div class="usa-banner__guidance tablet:grid-col-6">
           <img class="usa-banner__icon usa-media-block__img" src="{{ site.baseurl }}/assets/uswds/img/icon-dot-gov.svg" role="img" alt="Dot gov">

--- a/uswds-jekyll.gemspec
+++ b/uswds-jekyll.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name          = 'uswds-jekyll'
-  s.version       = '5.4.0'
+  s.version       = '5.5.0'
   s.authors       = ['Shawn Allen', 'Tom Black', 'Brian Hurst', 'Scott Weber', 'Dan O. Williams']
   s.email         = ['daniel.williams@gsa.gov']
 


### PR DESCRIPTION
Defaults the gov-banner to being hidden rather than waiting for USWDS to hide it. Bumps the minor version since it changes a behavior (thus not a patch) but in a non-breaking way (thus not major?).

Closes #256
